### PR TITLE
Fix: Require tests to pass on PHP 8.4

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -31,6 +31,9 @@ branches:
           - context: "Tests (8.3, highest)"
           - context: "Tests (8.3, locked)"
           - context: "Tests (8.3, lowest)"
+          - context: "Tests (8.4, highest)"
+          - context: "Tests (8.4, locked)"
+          - context: "Tests (8.4, lowest)"
         strict: false
       restrictions:
 


### PR DESCRIPTION
This pull request

- [x] requires tests to pass on PHP 8.4